### PR TITLE
fix: remove byebug dependency from production files

### DIFF
--- a/lib/ffi-cups.rb
+++ b/lib/ffi-cups.rb
@@ -1,5 +1,4 @@
 require 'ffi'
-require 'byebug'
 
 module Cups
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "bundler/setup"
+require 'byebug'
 require "cups_ffi"
 
 RSpec.configure do |config|


### PR DESCRIPTION
I'd prefer not to add `byebug` as a dependency on our production servers.