### PR TITLE
Replace File.exists? with File.exist?

### DIFF
--- a/lib/ffi-cups/printer.rb
+++ b/lib/ffi-cups/printer.rb
@@ -28,7 +28,7 @@ module Cups
     end
 
     def print_file(filename, title, options={})
-      raise "File not found: #{filename}" unless File.exists? filename
+      raise "File not found: #{filename}" unless File.exist? filename
       
       http = @connection.nil? ? nil : @connection.httpConnect2
       # Get all destinations with cupsGetDests2


### PR DESCRIPTION
## Problem

I wanted to use this gem for a quick print in Ruby 3 but it crashed at:

```rb
ruby/gems/3.2.0/gems/ffi-cups-0.3.1/lib/ffi-cups/printer.rb:31:in `print_file': undefined method `exists?' for File:Class (NoMethodError)

      raise "File not found: #{filename}" unless File.exists? filename
                                                     ^^^^^^^^
Did you mean?  exist?
```

## Solution

`File.exists?` alias was removed in Ruby 3.2.0. The singular form `File.exist?` should be used.

See: https://bugs.ruby-lang.org/issues/17391
> File.exists? has been deprecated since Ruby 2.1.0
