### PR TITLE
Update File.exist? syntax

### DIFF
--- a/lib/ffi-cups/printer.rb
+++ b/lib/ffi-cups/printer.rb
@@ -28,7 +28,7 @@ module Cups
     end
 
     def print_file(filename, title, options={})
-      raise "File not found: #{filename}" unless File.exists? filename
+      raise "File not found: #{filename}" unless File.exist? filename
       
       http = @connection.nil? ? nil : @connection.httpConnect2
       # Get all destinations with cupsGetDests2


### PR DESCRIPTION
The method `File.exists?` has been depreciated for a while now and was removed in Ruby 3.2 in favour of `File.exist?`.