### PR TITLE
Allow newer ffi gem versions

### DIFF
--- a/ffi-cups.gemspec
+++ b/ffi-cups.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  s.add_runtime_dependency "ffi", "~> 1.15.0"
+  s.add_runtime_dependency "ffi", "~> 1.15"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
The constraint was overly restrictive by allowing only version 1.15.x but not 1.16 or 1.17.

Thank you for this nice gem! It allows me to select and inspect the printer directly in my application and to print with all CUPS printing options.
