### PR TITLE
Add `find_dest_supported` to query for valid options of a printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,34 @@ require 'ffi-cups'
 
 printers = Cups::Printer.get_destinations
 # [#<Cups::Printer:0x000055fe50b15798 @name="Virtual_PDF_Printer",
-#  @options={"copies"=>"1", "device-uri"=>"cups-pdf:/", "finishings"=>"3" 
+#  @options={"copies"=>"1", "device-uri"=>"cups-pdf:/", "finishings"=>"3"
 #  "job-cancel-after"=>"10800", "job-hold-until"=>"no-hold", ...
 
 printer = Cups::Printer.get_destination("Virtual_PDF_Printer")
-# <Cups::Printer:0x0000560f1d4e0958 @name="Virtual_PDF_Printer", @options={"copies"=>"1" 
+# <Cups::Printer:0x0000560f1d4e0958 @name="Virtual_PDF_Printer", @options={"copies"=>"1"
 #   "device-uri"=>"cups-pdf:/", ...
 
 printer.state
-# :idle 
+# :idle
 
 printer.state_reasons
 # ["none"]
+
+printer.find_dest_supported
+# {type: :ipp_tag_keyword,
+#  values:
+#   ["copies",
+# ...
+#    "print-scaling",
+#    "printer-resolution",
+#    "sides"]}
+
+printer.find_dest_supported("copies")
+# {type: :ipp_tag_range, values: [{lowervalue: 1, uppervalue: 9999}]}
+
+printer.find_dest_supported("sides")
+# {type: :ipp_tag_keyword, values: ["one-sided", "two-sided-long-edge", "two-sided-short-edge"]}
+
 
 # Print a file (PDF, JPG, etc) you can pass a hash of printing options if you
 # want to override the printer's default. See Cups::Constants for more options
@@ -40,7 +56,7 @@ options = {
 }
 
 job = printer.print_file('/tmp/example.jpg', 'Title', options)
-# <Cups::Job:0x000055c87104d1e0 @id=10, @title="README", @printer="Virtual_PDF_Printer", @format="text/plain", @state=:processing, @size=4, @completed_time=1969-12-31 18:00:00 -0600, @creation_time=2021-04-18 17:35:04 -0500, @processing_time=2021-04-18 17:35:04 -0500> 
+# <Cups::Job:0x000055c87104d1e0 @id=10, @title="README", @printer="Virtual_PDF_Printer", @format="text/plain", @state=:processing, @size=4, @completed_time=1969-12-31 18:00:00 -0600, @creation_time=2021-04-18 17:35:04 -0500, @processing_time=2021-04-18 17:35:04 -0500>
 
 # Get all jobs from a printer
 jobs = Cups::Job.get_jobs('Virtual_PDF_Printer')

--- a/lib/ffi-cups.rb
+++ b/lib/ffi-cups.rb
@@ -21,16 +21,20 @@ require 'ffi-cups/enum/http/status'
 # IPP
 require 'ffi-cups/enum/ipp/status'
 require 'ffi-cups/enum/ipp/job_state'
+require 'ffi-cups/enum/ipp/res'
+require 'ffi-cups/enum/ipp/tag'
 
 # Structs
 require 'ffi-cups/struct/option'
 require 'ffi-cups/struct/destination'
 require 'ffi-cups/struct/job'
+require 'ffi-cups/struct/ipp_attribute'
 
 # Functions
 require 'ffi-cups/ffi/cups'
 require 'ffi-cups/ffi/http'
 require 'ffi-cups/ffi/array'
+require 'ffi-cups/ffi/ipp_attribute'
 
 # wrappers
 require 'ffi-cups/connection'

--- a/lib/ffi-cups/enum/ipp/res.rb
+++ b/lib/ffi-cups/enum/ipp/res.rb
@@ -1,0 +1,10 @@
+module Cups::Enum
+  module IPP
+    extend FFI::Library
+
+    Res = enum [  # ipp_res_e  # Resolution units
+      :ipp_res_per_inch, 3, # Pixels per inch
+      :ipp_res_per_cm,  # Pixels per centimeter
+    ]
+  end
+end

--- a/lib/ffi-cups/enum/ipp/tag.rb
+++ b/lib/ffi-cups/enum/ipp/tag.rb
@@ -1,0 +1,51 @@
+module Cups::Enum
+  module IPP
+    extend FFI::Library
+
+    Tag = enum [ # ipp_tag_e **** Format tags for attributes ****
+      :ipp_tag_cups_invalid, -1,		# Invalid tag name for @link ippTagValue@
+      :ipp_tag_zero, 0x00,			# Zero tag - used for separators
+      :ipp_tag_operation,			# operation group
+      :ipp_tag_job,				# job group
+      :ipp_tag_end,				# end-of-attributes
+      :ipp_tag_printer,			# printer group
+      :ipp_tag_unsupported_group,		# Unsupported attributes group
+      :ipp_tag_subscription,			# Subscription group
+      :ipp_tag_event_notification,		# Event group
+      :ipp_tag_resource,			# resource group @private@
+      :ipp_tag_document,			# document group
+      :ipp_tag_unsupported_value, 0x10,	# Unsupported value
+      :ipp_tag_default,			# default value
+      :ipp_tag_unknown,			# unknown value
+      :ipp_tag_novalue,			# no-value value
+      :ipp_tag_notsettable, 0x15,		# Not-settable value
+      :ipp_tag_deleteattr,			# delete-attribute value
+      :ipp_tag_admindefine,			# Admin-defined value
+      :ipp_tag_integer, 0x21,		# Integer value
+      :ipp_tag_boolean,			# boolean value
+      :ipp_tag_enum,				# enumeration value
+      :ipp_tag_string, 0x30,		# Octet string value
+      :ipp_tag_date,				# date/time value
+      :ipp_tag_resolution,			# resolution value
+      :ipp_tag_range,			# range value
+      :ipp_tag_begin_collection,		# Beginning of collection value
+      :ipp_tag_textlang,			# text-with-language value
+      :ipp_tag_namelang,			# name-with-language value
+      :ipp_tag_end_collection,		# End of collection value
+      :ipp_tag_text, 0x41,			# Text value
+      :ipp_tag_name,				# name value
+      :ipp_tag_reserved_string,		# Reserved for future string value @private@
+      :ipp_tag_keyword,			# keyword value
+      :ipp_tag_uri,				# uri value
+      :ipp_tag_urischeme,			# urI scheme value
+      :ipp_tag_charset,			# character set value
+      :ipp_tag_language,			# language value
+      :ipp_tag_mimetype,			# mimE media type value
+      :ipp_tag_membername,			# collection member name value
+      :ipp_tag_extension, 0x7f,		# Extension point for 32-bit tags
+      :ipp_tag_cups_mask, 0x7fffffff,	# Mask for copied attribute values @private@
+      # the following expression is used to avoid compiler warnings with +/-0x80000000
+      :ipp_tag_cups_const, -0x7fffffff-1	# Bitflag for copied/const attribute values @private@
+    ]
+  end
+end

--- a/lib/ffi-cups/ffi/cups.rb
+++ b/lib/ffi-cups/ffi/cups.rb
@@ -4,7 +4,7 @@
 
 module Cups
   extend FFI::Library
-  
+
   ffi_lib(Cups.libcups)
 
   # Get the current encryption settings.
@@ -22,6 +22,16 @@ module Cups
   #   @return [Integer] 1 if supported, 0 otherwise
   # {https://www.cups.org/doc/cupspm.html#cupsCheckDestSupported}
   attach_function 'cupsCheckDestSupported', [:pointer, :pointer, :pointer, :string, :string], :int, blocking: true
+
+  # Check that the option and value are supported by the destination.
+  # @overload cupsFindDestSupported(pointer, pointer, pointer, string)
+  #   @param http [Pointer]
+  #   @param destination [Pointer]
+  #   @param dinfo [Pointer]
+  #   @param option [String]
+  #   @return [p_ipp_attribute_t] opaque pointer to an IPP attribute
+  # {https://www.cups.org/doc/cupspm.html#cupsFindDestSupported}
+  attach_function 'cupsFindDestSupported', [:pointer, :pointer, :pointer, :string], Struct::IppAttribute.by_ref, blocking: true
 
   # Get the supported values/capabilities for the destination.
   # @overload cupsCopyDestInfo(pointer, pointer)
@@ -65,7 +75,7 @@ module Cups
   #   @param pointer [Pointer] to a CupsOptionS struct
   #   @return [Integer] job number or 0 on error
   attach_function 'cupsPrintFile', [ :string, :string, :string, :int, :pointer ], :int, blocking: true
-  
+
   # Prints a file from a specific connection
   # @overload cupsPrintFile2(pointer, string, string, string, int, pointer)
   #   @param pointer [Pointer] to an http connection

--- a/lib/ffi-cups/ffi/ipp_attribute.rb
+++ b/lib/ffi-cups/ffi/ipp_attribute.rb
@@ -1,0 +1,66 @@
+module Cups
+  module IppAttibute
+    extend FFI::Library
+
+    ffi_lib(Cups.libcups)
+
+    typedef Enum::IPP::Tag, :ipp_tag_t
+    typedef Enum::IPP::Res, :ipp_res_t
+
+    # Get the number of values in an attribute.
+    #
+    # @overload ippGetCount(pointer)
+    #   @param pointer [Struct::IppAttibute] to ipp_attribute_t struct
+    #   @return [Integer]
+    attach_function 'ippGetCount', [Struct::IppAttribute.by_ref], :int, blocking: true
+    attach_function 'ippGetGroupTag', [Struct::IppAttribute.by_ref], :ipp_tag_t, blocking: true
+    attach_function 'ippGetValueTag', [Struct::IppAttribute.by_ref], :ipp_tag_t, blocking: true
+    attach_function 'ippGetString', [Struct::IppAttribute.by_ref, :int, :pointer], :string, blocking: true
+    attach_function 'ippGetInteger', [Struct::IppAttribute.by_ref, :int], :int, blocking: true
+
+    #     Get a resolution value for an attribute.
+    #
+    # int ippGetResolution(ipp_attribute_t *attr, int element, int *yres, ipp_res_t *units);
+    # Parameters:
+    #   attr 	IPP attribute
+    #   element 	Value number (0-based)
+    #   yres 	Vertical/feed resolution
+    #   units 	Units for resolution
+    #
+    # Return Value: Horizontal/cross feed resolution or 0
+    #
+    # The element parameter specifies which value to get from 0 to ippGetCount(attr) - 1.
+    attach_function 'ippGetResolution', [Struct::IppAttribute.by_ref, :int, :pointer, :pointer], :int, blocking: true
+
+    #     Get a rangeOfInteger value from an attribute.
+    #
+    # int ippGetRange(ipp_attribute_t *attr, int element, int *uppervalue);
+    # Parameters:
+    #   attr 	IPP attribute
+    #   element 	Value number (0-based)
+    #   uppervalue 	Upper value of range
+    # Return Value:
+    #   Lower value of range or 0
+    #
+    # The element parameter specifies which value to get from 0 to ippGetCount(attr) - 1.
+    attach_function 'ippGetRange', [Struct::IppAttribute.by_ref, :int, :pointer], :int, blocking: true
+
+    #     Return a string corresponding to the enum value.
+    #
+    # const char *ippEnumString(const char *attrname, int enumvalue);
+    # Parameters:
+    #   attrname 	Attribute name
+    #   enumvalue 	Enum value
+    # Return Value: Enum string
+    attach_function 'ippEnumString', [:string, :int], :string, blocking: true
+
+    #     Return the value associated with a given enum string.
+    #
+    # int ippEnumValue(const char *attrname, const char *enumstring);
+    # Parameters:
+    #   attrname 	Attribute name
+    #   enumstring 	Enum string
+    # Return Value: Enum value or -1 if unknown
+    attach_function 'ippEnumValue', [:string, :string], :int, blocking: true
+  end
+end

--- a/lib/ffi-cups/struct/ipp_attribute.rb
+++ b/lib/ffi-cups/struct/ipp_attribute.rb
@@ -1,0 +1,6 @@
+module Cups::Struct
+  class IppAttribute < FFI::Struct
+    # ipp_attribute_t is an opaque pointer
+    layout  :dummy_dont_use, :char
+  end
+end


### PR DESCRIPTION
It uses `Cups::Struct::IppAttribute.by_ref` instead of a `:pointer` to ensure type safety.